### PR TITLE
Add organizationId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+**/target/**
+
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ String apiKey = System.getenv("OPENAI_API_KEY");
 
 OpenAiClient client = OpenAiClient.builder()
 	.openAiApiKey(apiKey)
+	.organizationId(orgId)
 	.callTimeout(ofSeconds(60))
 	.connectTimeout(ofSeconds(60))
 	.readTimeout(ofSeconds(60))

--- a/src/main/java/dev/ai4j/openai4j/ApiKeyHeaderInjector.java
+++ b/src/main/java/dev/ai4j/openai4j/ApiKeyHeaderInjector.java
@@ -1,27 +1,10 @@
 package dev.ai4j.openai4j;
 
-import okhttp3.Interceptor;
-import okhttp3.Request;
-import okhttp3.Response;
+import java.util.Collections;
 
-import java.io.IOException;
-
-class ApiKeyHeaderInjector implements Interceptor {
-
-    private final String apiKey;
+class ApiKeyHeaderInjector extends GenericHeaderInjector {
 
     ApiKeyHeaderInjector(String apiKey) {
-        this.apiKey = apiKey;
-    }
-
-    @Override
-    public Response intercept(Chain chain) throws IOException {
-
-        Request request = chain.request()
-                .newBuilder()
-                .addHeader("api-key", apiKey)
-                .build();
-
-        return chain.proceed(request);
+        super(Collections.singletonMap("api-key", apiKey));
     }
 }

--- a/src/main/java/dev/ai4j/openai4j/AuthorizationHeaderInjector.java
+++ b/src/main/java/dev/ai4j/openai4j/AuthorizationHeaderInjector.java
@@ -1,27 +1,10 @@
 package dev.ai4j.openai4j;
 
-import okhttp3.Interceptor;
-import okhttp3.Request;
-import okhttp3.Response;
+import java.util.Collections;
 
-import java.io.IOException;
-
-class AuthorizationHeaderInjector implements Interceptor {
-
-    private final String apiKey;
+class AuthorizationHeaderInjector extends GenericHeaderInjector {
 
     AuthorizationHeaderInjector(String apiKey) {
-        this.apiKey = apiKey;
-    }
-
-    @Override
-    public Response intercept(Chain chain) throws IOException {
-
-        Request request = chain.request()
-                .newBuilder()
-                .addHeader("Authorization", "Bearer " + apiKey)
-                .build();
-
-        return chain.proceed(request);
+        super(Collections.singletonMap("Authorization", "Bearer " + apiKey));
     }
 }

--- a/src/main/java/dev/ai4j/openai4j/DefaultOpenAiClient.java
+++ b/src/main/java/dev/ai4j/openai4j/DefaultOpenAiClient.java
@@ -1,5 +1,14 @@
 package dev.ai4j.openai4j;
 
+import static dev.ai4j.openai4j.Json.GSON;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import dev.ai4j.openai4j.chat.ChatCompletionRequest;
 import dev.ai4j.openai4j.chat.ChatCompletionResponse;
 import dev.ai4j.openai4j.completion.CompletionRequest;
@@ -11,15 +20,8 @@ import dev.ai4j.openai4j.moderation.ModerationResponse;
 import dev.ai4j.openai4j.moderation.ModerationResult;
 import okhttp3.Cache;
 import okhttp3.OkHttpClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
-
-import java.io.IOException;
-import java.util.List;
-
-import static dev.ai4j.openai4j.Json.GSON;
 
 public class DefaultOpenAiClient extends OpenAiClient {
 
@@ -56,6 +58,10 @@ public class DefaultOpenAiClient extends OpenAiClient {
             okHttpClientBuilder.addInterceptor(new AuthorizationHeaderInjector(serviceBuilder.openAiApiKey));
         } else {
             okHttpClientBuilder.addInterceptor(new ApiKeyHeaderInjector(serviceBuilder.azureApiKey));
+        }
+
+        if (serviceBuilder.organizationId != null) {
+            okHttpClientBuilder.addInterceptor(new GenericHeaderInjector(Collections.singletonMap("OpenAI-Organization", serviceBuilder.organizationId)));
         }
 
         if (serviceBuilder.proxy != null) {

--- a/src/main/java/dev/ai4j/openai4j/GenericHeaderInjector.java
+++ b/src/main/java/dev/ai4j/openai4j/GenericHeaderInjector.java
@@ -10,20 +10,20 @@ import okhttp3.Request.Builder;
 import okhttp3.Response;
 
 class GenericHeaderInjector implements Interceptor {
-	private final Map<String, String> headers = new HashMap<>();
+    private final Map<String, String> headers = new HashMap<>();
 
-	GenericHeaderInjector(Map<String, String> headers) {
-		Optional.ofNullable(headers)
-			.ifPresent(this.headers::putAll);
-	}
+    GenericHeaderInjector(Map<String, String> headers) {
+        Optional.ofNullable(headers)
+            .ifPresent(this.headers::putAll);
+    }
 
-	@Override
-	public Response intercept(Chain chain) throws IOException {
-		Builder builder = chain.request().newBuilder();
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Builder builder = chain.request().newBuilder();
 
-		// Add headers
-		this.headers.forEach(builder::addHeader);
+        // Add headers
+        this.headers.forEach(builder::addHeader);
 
-		return chain.proceed(builder.build());
-	}
+        return chain.proceed(builder.build());
+    }
 }

--- a/src/main/java/dev/ai4j/openai4j/GenericHeaderInjector.java
+++ b/src/main/java/dev/ai4j/openai4j/GenericHeaderInjector.java
@@ -1,0 +1,29 @@
+package dev.ai4j.openai4j;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import okhttp3.Interceptor;
+import okhttp3.Request.Builder;
+import okhttp3.Response;
+
+class GenericHeaderInjector implements Interceptor {
+	private final Map<String, String> headers = new HashMap<>();
+
+	GenericHeaderInjector(Map<String, String> headers) {
+		Optional.ofNullable(headers)
+			.ifPresent(this.headers::putAll);
+	}
+
+	@Override
+	public Response intercept(Chain chain) throws IOException {
+		Builder builder = chain.request().newBuilder();
+
+		// Add headers
+		this.headers.forEach(builder::addHeader);
+
+		return chain.proceed(builder.build());
+	}
+}

--- a/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
+++ b/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
@@ -1,5 +1,10 @@
 package dev.ai4j.openai4j;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.time.Duration;
+import java.util.List;
+
 import dev.ai4j.openai4j.chat.ChatCompletionRequest;
 import dev.ai4j.openai4j.chat.ChatCompletionResponse;
 import dev.ai4j.openai4j.completion.CompletionRequest;
@@ -11,11 +16,6 @@ import dev.ai4j.openai4j.moderation.ModerationResponse;
 import dev.ai4j.openai4j.moderation.ModerationResult;
 import dev.ai4j.openai4j.spi.OpenAiClientBuilderFactory;
 import dev.ai4j.openai4j.spi.ServiceHelper;
-
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-import java.time.Duration;
-import java.util.List;
 
 public abstract class OpenAiClient {
 
@@ -50,6 +50,7 @@ public abstract class OpenAiClient {
     public abstract static class Builder<T extends OpenAiClient, B extends Builder<T, B>> {
 
         public String baseUrl = "https://api.openai.com/v1/";
+        public String organizationId;
         public String apiVersion;
         public String openAiApiKey;
         public String azureApiKey;
@@ -75,6 +76,16 @@ public abstract class OpenAiClient {
                 throw new IllegalArgumentException("baseUrl cannot be null or empty");
             }
             this.baseUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+            return (B) this;
+        }
+
+        /**
+         *
+         * @param organizationId The organizationId for OpenAI: https://platform.openai.com/docs/api-reference/organization-optional
+         * @return builder
+         */
+        public B organizationId(String organizationId) {
+            this.organizationId = organizationId;
             return (B) this;
         }
 


### PR DESCRIPTION
Allow the organizationId to be specified in the configuration. See https://platform.openai.com/docs/api-reference/organization-optional

Right now there is no way to specify this.

Since this is also a header, I introduced a new `GenericHeaderInjector` and then also refactored `ApiKeyHeaderInjector` and `AuthorizationHeaderInjector` to use it. I didn't eliminate `ApiKeyHeaderInjector` and `AuthorizationHeaderInjector` because that would have been a breaking change.

I also added a few things to `.gitignore` that I noticed were added when I loaded the project into IntelliJ and ran a build locally.

Fixes #6