### PR TITLE
Ability to switch off making live calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ OpenAiClient client = OpenAiClient.builder()
 	.build();
 ```
 
+## Disabling a client from making live calls
+
+There may be instances where you want to disable the client from making "real" live calls as these calls can cost money. You can configure the builder using
+
+```java
+OpenAiClient client = OpenAiClient.builder()
+    .disableRequests()
+    // Other customizations
+    .build();
+```
+
+For synchronous operations this will cause the `execute()` method to throw an `OpenAiHttpException`.
+
+For asynchronous/streaming operations this will cause the `execute()` method to call the `onError` callback with an `OpenAiHttpException`.
+
 ## Completions
 
 ### Synchronously

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
+++ b/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
@@ -1,5 +1,7 @@
 package dev.ai4j.openai4j;
 
+import static dev.ai4j.openai4j.LogLevel.DEBUG;
+
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.nio.file.Path;
@@ -20,8 +22,6 @@ import dev.ai4j.openai4j.moderation.ModerationResponse;
 import dev.ai4j.openai4j.moderation.ModerationResult;
 import dev.ai4j.openai4j.spi.OpenAiClientBuilderFactory;
 import dev.ai4j.openai4j.spi.ServiceHelper;
-
-import static dev.ai4j.openai4j.LogLevel.DEBUG;
 
 public abstract class OpenAiClient {
 
@@ -72,6 +72,7 @@ public abstract class OpenAiClient {
         public LogLevel logLevel = DEBUG;
         public boolean logStreamingResponses;
         public Path persistTo;
+        public boolean enableRequests = true;
 
         public abstract T build();
 
@@ -187,6 +188,24 @@ public abstract class OpenAiClient {
                 logRequests = false;
             }
             this.logRequests = logRequests;
+            return (B) this;
+        }
+
+        public B disableRequests() {
+            return enableRequests(false);
+        }
+
+        /**
+         * Whether or not to enable live communication over the wire
+         * @param enableRequests {@code true} to enable communication over the wire. {@code false} otherwise.
+         *                            {@code false} results in an exception being thrown instead of making a request.
+         * @return builder
+         */
+        public B enableRequests(Boolean enableRequests) {
+            if (enableRequests == null) {
+                enableRequests = true;
+            }
+            this.enableRequests = enableRequests;
             return (B) this;
         }
 

--- a/src/main/java/dev/ai4j/openai4j/RequestDisablerInterceptor.java
+++ b/src/main/java/dev/ai4j/openai4j/RequestDisablerInterceptor.java
@@ -1,0 +1,21 @@
+package dev.ai4j.openai4j;
+
+import okhttp3.Interceptor;
+import okhttp3.Protocol;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+public class RequestDisablerInterceptor implements Interceptor {
+    private static final String MESSAGE = "Requests to the live system are disabled";
+
+    @Override
+    public Response intercept(Chain chain) {
+        return new Response.Builder()
+            .request(chain.request())
+            .protocol(Protocol.HTTP_1_1)
+            .code(400)
+            .message(MESSAGE)
+            .body(ResponseBody.create(MESSAGE, null))
+            .build();
+    }
+}

--- a/src/test/java/dev/ai4j/openai4j/chat/RequestDisabledChatCompletionAsyncTest.java
+++ b/src/test/java/dev/ai4j/openai4j/chat/RequestDisabledChatCompletionAsyncTest.java
@@ -1,0 +1,280 @@
+package dev.ai4j.openai4j.chat;
+
+import static dev.ai4j.openai4j.chat.ChatCompletionModel.GPT_4_VISION_PREVIEW;
+import static dev.ai4j.openai4j.chat.ChatCompletionTest.*;
+import static dev.ai4j.openai4j.chat.ResponseFormatType.*;
+import static java.util.Collections.singletonMap;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import dev.ai4j.openai4j.OpenAiClient;
+import dev.ai4j.openai4j.OpenAiHttpException;
+
+class RequestDisabledChatCompletionAsyncTest {
+
+    private final OpenAiClient client = OpenAiClient.builder()
+            .disableRequests()
+            .logRequests()
+            .logResponses()
+            .build();
+
+    @Test
+    void testSimpleApi() {
+
+        // when
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        client.chatCompletion(USER_MESSAGE)
+                .onResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .execute();
+
+        assertThat(future.isCompletedExceptionally()).isTrue();
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613", // I don't have access to these models
+            "GPT_4_VISION_PREVIEW" // Does not support many things now, including logit_bias and response_format
+    })
+    void testCustomizableApi(ChatCompletionModel model) {
+
+        // given
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .addSystemMessage(SYSTEM_MESSAGE)
+                .addUserMessage(USER_MESSAGE)
+                .temperature(1.0)
+                .topP(0.1)
+                .n(1)
+                .stream(false)
+                .stop("one", "two")
+                .maxTokens(3)
+                .presencePenalty(0.0)
+                .frequencyPenalty(0.0)
+                .logitBias(singletonMap("50256", -100))
+                .user("Klaus")
+                .responseFormat(TEXT)
+                .seed(42)
+                .build();
+
+        CompletableFuture<ChatCompletionResponse> future = new CompletableFuture<>();
+
+        // when
+        client.chatCompletion(request)
+                .onResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .execute();
+
+        assertThat(future.isCompletedExceptionally()).isTrue();
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613", // I don't have access to these models
+            "GPT_4_0314", // Does not support tools/functions
+            "GPT_4_VISION_PREVIEW" // Does not support many things now, including tools
+    })
+    void testTools(ChatCompletionModel model) {
+
+        // given
+        UserMessage userMessage = UserMessage.from("What is the weather like in Boston?");
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .messages(userMessage)
+                .tools(WEATHER_TOOL)
+                .build();
+
+        CompletableFuture<ChatCompletionResponse> future = new CompletableFuture<>();
+
+        // when
+        client.chatCompletion(request)
+                .onResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .execute();
+
+        assertThat(future.isCompletedExceptionally()).isTrue();
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613", // I don't have access to these models
+            "GPT_4_0314", // Does not support tools/functions
+            "GPT_4_VISION_PREVIEW" // Does not support many things now, including functions
+    })
+    void testFunctions(ChatCompletionModel model) {
+
+        // given
+        UserMessage userMessage = UserMessage.from("What is the weather like in Boston?");
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .messages(userMessage)
+                .functions(WEATHER_FUNCTION)
+                .build();
+
+        CompletableFuture<ChatCompletionResponse> future = new CompletableFuture<>();
+
+        // when
+        client.chatCompletion(request)
+                .onResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .execute();
+
+        assertThat(future.isCompletedExceptionally()).isTrue();
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613", // I don't have access to these models
+            "GPT_4_0314", // Does not support tools/functions
+            "GPT_4_VISION_PREVIEW" // does not support many things now, including tools
+    })
+    void testToolChoice(ChatCompletionModel model) {
+
+        // given
+        UserMessage userMessage = UserMessage.from("What is the weather like in Boston?");
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .messages(userMessage)
+                .tools(WEATHER_TOOL)
+                .toolChoice(WEATHER_TOOL_NAME)
+                .build();
+
+        CompletableFuture<ChatCompletionResponse> future = new CompletableFuture<>();
+
+        // when
+        client.chatCompletion(request)
+                .onResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .execute();
+
+        assertThat(future.isCompletedExceptionally()).isTrue();
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613", // I don't have access to these models
+            "GPT_4_0314", // Does not support tools/functions
+            "GPT_4_VISION_PREVIEW" // does not support many things now, including tools
+    })
+    void testFunctionChoice(ChatCompletionModel model) {
+
+        // given
+        UserMessage userMessage = UserMessage.from("What is the weather like in Boston?");
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .messages(userMessage)
+                .functions(WEATHER_FUNCTION)
+                .functionCall(WEATHER_TOOL_NAME)
+                .build();
+
+        CompletableFuture<ChatCompletionResponse> future = new CompletableFuture<>();
+
+        // when
+        client.chatCompletion(request)
+                .onResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .execute();
+
+        assertThat(future.isCompletedExceptionally()).isTrue();
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = INCLUDE, names = {"GPT_3_5_TURBO_1106", "GPT_4_1106_PREVIEW"})
+    void testJsonResponseFormat(ChatCompletionModel model) {
+
+        // given
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .addUserMessage("Extract information from the following text:\n" +
+                        "Who is Klaus Heisler?\n" +
+                        "Respond in JSON format with two fields: 'name' and 'surname'")
+                .responseFormat(JSON_OBJECT)
+                .build();
+
+        CompletableFuture<ChatCompletionResponse> future = new CompletableFuture<>();
+
+        // when
+        client.chatCompletion(request)
+                .onResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .execute();
+
+        assertThat(future.isCompletedExceptionally()).isTrue();
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @Test
+    void testGpt4Vision() {
+
+        // given
+        String imageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg";
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(GPT_4_VISION_PREVIEW)
+                .messages(UserMessage.from("What is in this image?", imageUrl))
+                .maxTokens(100)
+                .build();
+
+        CompletableFuture<ChatCompletionResponse> future = new CompletableFuture<>();
+
+        // when
+        client.chatCompletion(request)
+                .onResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .execute();
+
+        assertThat(future.isCompletedExceptionally()).isTrue();
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+}

--- a/src/test/java/dev/ai4j/openai4j/chat/RequestDisabledChatCompletionStreamingTest.java
+++ b/src/test/java/dev/ai4j/openai4j/chat/RequestDisabledChatCompletionStreamingTest.java
@@ -1,0 +1,461 @@
+package dev.ai4j.openai4j.chat;
+
+import static dev.ai4j.openai4j.chat.ChatCompletionModel.GPT_4_VISION_PREVIEW;
+import static dev.ai4j.openai4j.chat.ChatCompletionTest.*;
+import static dev.ai4j.openai4j.chat.ResponseFormatType.*;
+import static dev.ai4j.openai4j.chat.ToolType.FUNCTION;
+import static java.util.Collections.singletonMap;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.*;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import dev.ai4j.openai4j.OpenAiClient;
+import dev.ai4j.openai4j.OpenAiHttpException;
+
+class RequestDisabledChatCompletionStreamingTest {
+
+    private final OpenAiClient client = OpenAiClient.builder()
+            .disableRequests()
+            .logRequests()
+            .logResponses()
+            .logStreamingResponses()
+            .build();
+
+    @Test
+    void testSimpleApi() {
+
+        // when
+        StringBuilder responseBuilder = new StringBuilder();
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        client.chatCompletion(USER_MESSAGE)
+                .onPartialResponse(responseBuilder::append)
+                .onComplete(() -> future.complete(responseBuilder.toString()))
+                .onError(future::completeExceptionally)
+                .execute();
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613", // I don't have access to these models
+            "GPT_4_VISION_PREVIEW" // Does not support many things now, including logit_bias and response_format
+    })
+    void testCustomizableApi(ChatCompletionModel model) {
+
+        // given
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .addSystemMessage(SYSTEM_MESSAGE)
+                .addUserMessage(USER_MESSAGE)
+                .temperature(1.0)
+                .topP(0.1)
+                .n(1)
+                .stream(false) // intentionally setting to false in order to test that it is ignored
+                .stop("one", "two")
+                .maxTokens(3)
+                .presencePenalty(0.0)
+                .frequencyPenalty(0.0)
+                .logitBias(singletonMap("50256", -100))
+                .user("Klaus")
+                .responseFormat(TEXT)
+                .seed(42)
+                .build();
+
+        // when
+        StringBuilder responseBuilder = new StringBuilder();
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        client.chatCompletion(request)
+                .onPartialResponse(partialResponse -> {
+                    String content = partialResponse.choices().get(0).delta().content();
+                    if (content != null) {
+                        responseBuilder.append(content);
+                    }
+                })
+                .onComplete(() -> future.complete(responseBuilder.toString()))
+                .onError(future::completeExceptionally)
+                .execute();
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613", // I don't have access to these models
+            "GPT_4_0314", // Does not support tools/functions
+            "GPT_4_VISION_PREVIEW" // Does not support many things now, including tools
+    })
+    void testTools(ChatCompletionModel model)  {
+
+        // given
+        UserMessage userMessage = UserMessage.from("What is the weather like in Boston?");
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .messages(userMessage)
+                .tools(WEATHER_TOOL)
+                .build();
+
+        // when
+        StringBuilder toolIdBuilder = new StringBuilder();
+        StringBuilder functionNameBuilder = new StringBuilder();
+        StringBuilder functionArgumentsBuilder = new StringBuilder();
+        CompletableFuture<AssistantMessage> future = new CompletableFuture<>();
+
+        client.chatCompletion(request)
+                .onPartialResponse(partialResponse -> {
+                    Delta delta = partialResponse.choices().get(0).delta();
+                    assertThat(delta.content()).isNull();
+                    assertThat(delta.functionCall()).isNull();
+
+                    if (delta.toolCalls() != null) {
+                        assertThat(delta.toolCalls()).hasSize(1);
+
+                        ToolCall toolCall = delta.toolCalls().get(0);
+                        assertThat(toolCall.type()).isIn(null, FUNCTION);
+                        assertThat(toolCall.function()).isNotNull();
+
+                        if (toolCall.id() != null) {
+                            toolIdBuilder.append(toolCall.id());
+                        }
+
+                        FunctionCall functionCall = toolCall.function();
+                        if (functionCall.name() != null) {
+                            functionNameBuilder.append(functionCall.name());
+                        }
+                        if (functionCall.arguments() != null) {
+                            functionArgumentsBuilder.append(functionCall.arguments());
+                        }
+                    }
+                })
+                .onComplete(() -> {
+                    AssistantMessage assistantMessage = AssistantMessage.builder()
+                            .toolCalls(ToolCall.builder()
+                                    .id(toolIdBuilder.toString())
+                                    .type(FUNCTION)
+                                    .function(FunctionCall.builder()
+                                            .name(functionNameBuilder.toString())
+                                            .arguments(functionArgumentsBuilder.toString())
+                                            .build())
+                                    .build())
+                            .build();
+                    future.complete(assistantMessage);
+                })
+                .onError(future::completeExceptionally)
+                .execute();
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613", // I don't have access to these models
+            "GPT_4_0314", // Does not support tools/functions
+            "GPT_4_VISION_PREVIEW" // Does not support many things now, including tools
+    })
+    void testFunctions(ChatCompletionModel model)  {
+
+        // given
+        UserMessage userMessage = UserMessage.from("What is the weather like in Boston?");
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .messages(userMessage)
+                .functions(WEATHER_FUNCTION)
+                .build();
+
+        // when
+        StringBuilder functionNameBuilder = new StringBuilder();
+        StringBuilder functionArgumentsBuilder = new StringBuilder();
+        CompletableFuture<AssistantMessage> future = new CompletableFuture<>();
+
+        client.chatCompletion(request)
+                .onPartialResponse(partialResponse -> {
+                    Delta delta = partialResponse.choices().get(0).delta();
+                    assertThat(delta.content()).isNull();
+                    assertThat(delta.toolCalls()).isNull();
+
+                    if (delta.functionCall() != null) {
+                        FunctionCall functionCall = delta.functionCall();
+                        if (functionCall.name() != null) {
+                            functionNameBuilder.append(functionCall.name());
+                        }
+                        if (functionCall.arguments() != null) {
+                            functionArgumentsBuilder.append(functionCall.arguments());
+                        }
+                    }
+                })
+                .onComplete(() -> {
+                    AssistantMessage assistantMessage = AssistantMessage.builder()
+                            .functionCall(FunctionCall.builder()
+                                    .name(functionNameBuilder.toString())
+                                    .arguments(functionArgumentsBuilder.toString())
+                                    .build())
+                            .build();
+                    future.complete(assistantMessage);
+                })
+                .onError(future::completeExceptionally)
+                .execute();
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613", // I don't have access to these models
+            "GPT_4_0314", // Does not support tools/functions
+            "GPT_4_VISION_PREVIEW" // does not support many things now, including tools
+    })
+    void testToolChoice(ChatCompletionModel model)  {
+
+        // given
+        UserMessage userMessage = UserMessage.from("What is the weather like in Boston?");
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .messages(userMessage)
+                .tools(WEATHER_TOOL)
+                .toolChoice(WEATHER_TOOL_NAME)
+                .build();
+
+        // when
+        StringBuilder toolIdBuilder = new StringBuilder();
+        StringBuilder functionNameBuilder = new StringBuilder();
+        StringBuilder functionArgumentsBuilder = new StringBuilder();
+        CompletableFuture<AssistantMessage> future = new CompletableFuture<>();
+
+        client.chatCompletion(request)
+                .onPartialResponse(partialResponse -> {
+                    Delta delta = partialResponse.choices().get(0).delta();
+                    assertThat(delta.content()).isNull();
+                    assertThat(delta.functionCall()).isNull();
+
+                    if (delta.toolCalls() != null) {
+                        assertThat(delta.toolCalls()).hasSize(1);
+
+                        ToolCall toolCall = delta.toolCalls().get(0);
+                        assertThat(toolCall.type()).isIn(null, FUNCTION);
+                        assertThat(toolCall.function()).isNotNull();
+
+                        if (toolCall.id() != null) {
+                            toolIdBuilder.append(toolCall.id());
+                        }
+
+                        FunctionCall functionCall = toolCall.function();
+                        if (functionCall.name() != null) {
+                            functionNameBuilder.append(functionCall.name());
+                        }
+                        if (functionCall.arguments() != null) {
+                            functionArgumentsBuilder.append(functionCall.arguments());
+                        }
+                    }
+                })
+                .onComplete(() -> {
+                    AssistantMessage assistantMessage = AssistantMessage.builder()
+                            .toolCalls(ToolCall.builder()
+                                    .id(toolIdBuilder.toString())
+                                    .type(FUNCTION)
+                                    .function(FunctionCall.builder()
+                                            .name(functionNameBuilder.toString())
+                                            .arguments(functionArgumentsBuilder.toString())
+                                            .build())
+                                    .build())
+                            .build();
+                    future.complete(assistantMessage);
+                })
+                .onError(future::completeExceptionally)
+                .execute();
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613", // I don't have access to these models
+            "GPT_4_0314", // Does not support tools/functions
+            "GPT_4_VISION_PREVIEW" // does not support many things now, including tools
+    })
+    void testFunctionChoice(ChatCompletionModel model)  {
+
+        // given
+        UserMessage userMessage = UserMessage.from("What is the weather like in Boston?");
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .messages(userMessage)
+                .functions(WEATHER_FUNCTION)
+                .functionCall(WEATHER_TOOL_NAME)
+                .build();
+
+        // when
+        StringBuilder functionNameBuilder = new StringBuilder();
+        StringBuilder functionArgumentsBuilder = new StringBuilder();
+        CompletableFuture<AssistantMessage> future = new CompletableFuture<>();
+
+        client.chatCompletion(request)
+                .onPartialResponse(partialResponse -> {
+                    Delta delta = partialResponse.choices().get(0).delta();
+                    assertThat(delta.content()).isNull();
+                    assertThat(delta.toolCalls()).isNull();
+
+                    if (delta.functionCall() != null) {
+                        FunctionCall functionCall = delta.functionCall();
+                        if (functionCall.name() != null) {
+                            functionNameBuilder.append(functionCall.name());
+                        }
+                        if (functionCall.arguments() != null) {
+                            functionArgumentsBuilder.append(functionCall.arguments());
+                        }
+                    }
+                })
+                .onComplete(() -> {
+                    AssistantMessage assistantMessage = AssistantMessage.builder()
+                            .functionCall(FunctionCall.builder()
+                                    .name(functionNameBuilder.toString())
+                                    .arguments(functionArgumentsBuilder.toString())
+                                    .build())
+                            .build();
+                    future.complete(assistantMessage);
+                })
+                .onError(future::completeExceptionally)
+                .execute();
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = INCLUDE, names = {"GPT_3_5_TURBO_1106", "GPT_4_1106_PREVIEW"})
+    void testJsonResponseFormat(ChatCompletionModel model)  {
+
+        // given
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .addUserMessage("Extract information from the following text:\n" +
+                        "Who is Klaus Heisler?\n" +
+                        "Respond in JSON format with two fields: 'name' and 'surname'")
+                .responseFormat(JSON_OBJECT)
+                .build();
+
+        // when
+        StringBuilder responseBuilder = new StringBuilder();
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        client.chatCompletion(request)
+                .onPartialResponse(partialResponse -> {
+                    Delta delta = partialResponse.choices().get(0).delta();
+                    if (delta.content() != null) {
+                        responseBuilder.append(delta.content());
+                    }
+                })
+                .onComplete(() -> future.complete(responseBuilder.toString()))
+                .onError(future::completeExceptionally)
+                .execute();
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @Test
+    void testGpt4Vision()  {
+
+        // given
+        String imageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg";
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(GPT_4_VISION_PREVIEW)
+                .messages(UserMessage.from("What is in this image?", imageUrl))
+                .maxTokens(100)
+                .build();
+
+        // when
+        StringBuilder responseBuilder = new StringBuilder();
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        client.chatCompletion(request)
+                .onPartialResponse(partialResponse -> {
+                    Delta delta = partialResponse.choices().get(0).delta();
+                    if (delta.content() != null) {
+                        responseBuilder.append(delta.content());
+                    }
+                })
+                .onComplete(() -> future.complete(responseBuilder.toString()))
+                .onError(future::completeExceptionally)
+                .execute();
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+}

--- a/src/test/java/dev/ai4j/openai4j/chat/RequestDisabledChatCompletionTest.java
+++ b/src/test/java/dev/ai4j/openai4j/chat/RequestDisabledChatCompletionTest.java
@@ -1,0 +1,224 @@
+package dev.ai4j.openai4j.chat;
+
+import static dev.ai4j.openai4j.chat.ChatCompletionModel.GPT_4_VISION_PREVIEW;
+import static dev.ai4j.openai4j.chat.JsonSchemaProperty.*;
+import static dev.ai4j.openai4j.chat.ResponseFormatType.*;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import dev.ai4j.openai4j.OpenAiClient;
+import dev.ai4j.openai4j.OpenAiHttpException;
+
+class RequestDisabledChatCompletionTest {
+
+    static final String SYSTEM_MESSAGE = "Be concise";
+    static final String USER_MESSAGE = "Write exactly the following 2 words: 'hello world'";
+
+    static final String WEATHER_TOOL_NAME = "get_current_weather";
+    static final Function WEATHER_FUNCTION = Function.builder()
+            .name(WEATHER_TOOL_NAME)
+            .description("Get the current weather in a given location")
+            .addParameter("location", STRING, description("The city and state, e.g. San Francisco, CA"))
+            .addOptionalParameter("unit", STRING, enums(Unit.class))
+            .build();
+    static final Tool WEATHER_TOOL = Tool.from(WEATHER_FUNCTION);
+
+    private final OpenAiClient client = OpenAiClient.builder()
+            .disableRequests()
+            .logRequests()
+            .logResponses()
+            .build();
+
+    @Test
+    void testSimpleApi() {
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.chatCompletion(USER_MESSAGE).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613", // I don't have access to these models
+            "GPT_4_VISION_PREVIEW" // Does not support many things now, including logit_bias and response_format
+    })
+    void testCustomizableApi(ChatCompletionModel model) {
+
+        // given
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .addSystemMessage(SYSTEM_MESSAGE)
+                .addUserMessage(USER_MESSAGE)
+                .temperature(1.0)
+                .topP(0.1)
+                .n(1)
+                .stream(false)
+                .stop("one", "two")
+                .maxTokens(3)
+                .presencePenalty(0.0)
+                .frequencyPenalty(0.0)
+                .logitBias(singletonMap("50256", -100))
+                .user("Klaus")
+                .responseFormat(TEXT)
+                .seed(42)
+                .build();
+
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.chatCompletion(request).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613", // I don't have access to these models
+            "GPT_4_0314", // Does not support tools/functions
+            "GPT_4_VISION_PREVIEW" // Does not support many things now, including tools
+    })
+    void testTools(ChatCompletionModel model) {
+
+        // given
+        UserMessage userMessage = UserMessage.from("What is the weather like in Boston?");
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .messages(userMessage)
+                .tools(WEATHER_TOOL)
+                .build();
+
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.chatCompletion(request).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613", // I don't have access to these models
+            "GPT_4_0314", // Does not support tools/functions
+            "GPT_4_VISION_PREVIEW" // Does not support many things now, including functions
+    })
+    void testFunctions(ChatCompletionModel model) {
+
+        // given
+        UserMessage userMessage = UserMessage.from("What is the weather like in Boston?");
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .messages(userMessage)
+                .functions(WEATHER_FUNCTION)
+                .build();
+
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.chatCompletion(request).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613", // I don't have access to these models
+            "GPT_4_0314", // Does not support tools/functions
+            "GPT_4_VISION_PREVIEW" // does not support many things now, including tools
+    })
+    void testToolChoice(ChatCompletionModel model) {
+
+        // given
+        UserMessage userMessage = UserMessage.from("What is the weather like in Boston?");
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .messages(userMessage)
+                .tools(WEATHER_TOOL)
+                .toolChoice(WEATHER_TOOL_NAME)
+                .build();
+
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.chatCompletion(request).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613", // I don't have access to these models
+            "GPT_4_0314", // Does not support tools/functions
+            "GPT_4_VISION_PREVIEW" // does not support many things now, including tools
+    })
+    void testFunctionChoice(ChatCompletionModel model) {
+
+        // given
+        UserMessage userMessage = UserMessage.from("What is the weather like in Boston?");
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .messages(userMessage)
+                .functions(WEATHER_FUNCTION)
+                .functionCall(WEATHER_TOOL_NAME)
+                .build();
+
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.chatCompletion(request).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    enum Unit {
+        CELSIUS, FAHRENHEIT
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = INCLUDE, names = {"GPT_3_5_TURBO_1106", "GPT_4_1106_PREVIEW"})
+    void testJsonResponseFormat(ChatCompletionModel model) {
+
+        // given
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .addUserMessage("Extract information from the following text:\n" +
+                        "Who is Klaus Heisler?\n" +
+                        "Respond in JSON format with two fields: 'name' and 'surname'")
+                .responseFormat(JSON_OBJECT)
+                .build();
+
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.chatCompletion(request).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @Test
+    void testGpt4Vision() {
+
+        // given
+        String imageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg";
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(GPT_4_VISION_PREVIEW)
+                .messages(UserMessage.from("What is in this image?", imageUrl))
+                .maxTokens(100)
+                .build();
+
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.chatCompletion(request).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ChatCompletionModel.class, mode = EXCLUDE, names = {
+            "GPT_4_32K", "GPT_4_32K_0314", "GPT_4_32K_0613" // I don't have access to these models
+    })
+    void testUserMessageWithStringContent(ChatCompletionModel model) {
+
+        // given
+        UserMessage userMessage = UserMessage.builder()
+                .content("What is the capital of Germany?")
+                .build();
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(model)
+                .messages(userMessage)
+                .build();
+
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.chatCompletion(request).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+}

--- a/src/test/java/dev/ai4j/openai4j/completion/RequestDisabledCompletionAsyncTest.java
+++ b/src/test/java/dev/ai4j/openai4j/completion/RequestDisabledCompletionAsyncTest.java
@@ -1,0 +1,69 @@
+package dev.ai4j.openai4j.completion;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.Test;
+
+import dev.ai4j.openai4j.OpenAiClient;
+import dev.ai4j.openai4j.OpenAiHttpException;
+
+class RequestDisabledCompletionAsyncTest {
+
+    private static final String PROMPT = "write exactly the following 2 words: 'hello world'";
+
+    private final OpenAiClient client = OpenAiClient.builder()
+            .logRequests()
+            .logResponses()
+            .disableRequests()
+            .build();
+
+    @Test
+    void testSimpleApi() {
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        client.completion(PROMPT)
+                .onResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .execute();
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @Test
+    void testCustomizableApi() {
+        CompletionRequest request = CompletionRequest.builder()
+                .prompt(PROMPT)
+                .build();
+
+        CompletableFuture<CompletionResponse> future = new CompletableFuture<>();
+
+        client.completion(request)
+                .onResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .execute();
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+}

--- a/src/test/java/dev/ai4j/openai4j/completion/RequestDisabledCompletionStreamingTest.java
+++ b/src/test/java/dev/ai4j/openai4j/completion/RequestDisabledCompletionStreamingTest.java
@@ -1,0 +1,124 @@
+package dev.ai4j.openai4j.completion;
+
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import dev.ai4j.openai4j.OpenAiClient;
+import dev.ai4j.openai4j.OpenAiHttpException;
+import dev.ai4j.openai4j.ResponseHandle;
+
+class RequestDisabledCompletionStreamingTest {
+
+    private static final String PROMPT = "write exactly the following 2 words: 'hello world'";
+
+    private final OpenAiClient client = OpenAiClient.builder()
+            .disableRequests()
+            .logRequests()
+            .logResponses()
+            .logStreamingResponses()
+            .build();
+
+    @Test
+    void testSimpleApi() {
+
+        StringBuilder responseBuilder = new StringBuilder();
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+
+        client.completion(PROMPT)
+                .onPartialResponse(responseBuilder::append)
+                .onComplete(() -> future.complete(responseBuilder.toString()))
+                .onError(future::completeExceptionally)
+                .execute();
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @Test
+    void testCustomizableApi() {
+
+        StringBuilder responseBuilder = new StringBuilder();
+        CompletableFuture<String> future = new CompletableFuture<>();
+
+        CompletionRequest request = CompletionRequest.builder()
+                .prompt(PROMPT)
+                .build();
+
+
+        client.completion(request)
+                .onPartialResponse(response -> responseBuilder.append(response.text()))
+                .onComplete(() -> future.complete(responseBuilder.toString()))
+                .onError(future::completeExceptionally)
+                .execute();
+
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @Test
+    void testCancelStreaming() throws InterruptedException {
+
+        OpenAiClient client = OpenAiClient.builder()
+                // without caching
+                .disableRequests()
+                .logRequests()
+                .logResponses()
+                .logStreamingResponses()
+                .build();
+
+        AtomicBoolean streamingStarted = new AtomicBoolean(false);
+        AtomicBoolean completed = new AtomicBoolean(false);
+        AtomicBoolean errorSucceeded = new AtomicBoolean(false);
+
+        ResponseHandle responseHandle = client.completion("Write a poem about AI in 10 words")
+                .onPartialResponse(partialResponse -> {
+                    streamingStarted.set(true);
+                    System.out.println("[[streaming started]]");
+                })
+                .onComplete(() -> {
+                    completed.set(true);
+                    System.out.println("[[completed]]");
+                })
+                .onError(e -> {
+                    errorSucceeded.set(true);
+                    System.out.println("[[failed]]");
+                })
+                .execute();
+
+        Thread.sleep(2000);
+
+        newSingleThreadExecutor().execute(() -> {
+            responseHandle.cancel();
+            System.out.println("[[streaming cancelled]]");
+        });
+
+        assertThat(streamingStarted).isFalse();
+        assertThat(errorSucceeded).isTrue();
+        assertThat(completed).isFalse();
+    }
+}

--- a/src/test/java/dev/ai4j/openai4j/completion/RequestDisabledCompletionTest.java
+++ b/src/test/java/dev/ai4j/openai4j/completion/RequestDisabledCompletionTest.java
@@ -1,0 +1,36 @@
+package dev.ai4j.openai4j.completion;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.api.Test;
+
+import dev.ai4j.openai4j.OpenAiClient;
+import dev.ai4j.openai4j.OpenAiHttpException;
+
+public class RequestDisabledCompletionTest {
+    private static final String PROMPT = "write exactly the following 2 words: 'hello world'";
+
+    private final OpenAiClient client = OpenAiClient.builder()
+            .disableRequests()
+            .logRequests()
+            .logResponses()
+            .build();
+
+    @Test
+    void testSimpleApi() {
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.completion(PROMPT).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @Test
+    void testCustomizableApi() {
+        CompletionRequest request = CompletionRequest.builder()
+                .prompt(PROMPT)
+                .build();
+
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.completion(request).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+}

--- a/src/test/java/dev/ai4j/openai4j/embedding/RequestDisabledEmbeddingsAsyncTest.java
+++ b/src/test/java/dev/ai4j/openai4j/embedding/RequestDisabledEmbeddingsAsyncTest.java
@@ -1,0 +1,73 @@
+package dev.ai4j.openai4j.embedding;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.Test;
+
+import dev.ai4j.openai4j.OpenAiClient;
+import dev.ai4j.openai4j.OpenAiHttpException;
+
+public class RequestDisabledEmbeddingsAsyncTest {
+
+    private static final String INPUT = "hello";
+
+    private final OpenAiClient client = OpenAiClient.builder()
+            .disableRequests()
+            .logRequests()
+            .logResponses()
+            .build();
+
+    @Test
+    void testSimpleApi() {
+
+        CompletableFuture<List<Float>> future = new CompletableFuture<>();
+
+        client.embedding(INPUT)
+                .onResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .execute();
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @Test
+    void testCustomizableApi() {
+
+        EmbeddingRequest request = EmbeddingRequest.builder()
+                .input(INPUT)
+                .build();
+
+        CompletableFuture<EmbeddingResponse> future = new CompletableFuture<>();
+
+
+        client.embedding(request)
+                .onResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .execute();
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+}

--- a/src/test/java/dev/ai4j/openai4j/embedding/RequestDisabledEmbeddingsTest.java
+++ b/src/test/java/dev/ai4j/openai4j/embedding/RequestDisabledEmbeddingsTest.java
@@ -1,0 +1,55 @@
+package dev.ai4j.openai4j.embedding;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import dev.ai4j.openai4j.OpenAiClient;
+import dev.ai4j.openai4j.OpenAiHttpException;
+
+public class RequestDisabledEmbeddingsTest {
+
+    private static final String INPUT = "hello";
+
+    private final OpenAiClient client = OpenAiClient.builder()
+            .disableRequests()
+            .logRequests()
+            .logResponses()
+            .build();
+
+    @Test
+    void testSimpleApi() {
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.embedding("hello").execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void testCustomizableApi(EmbeddingRequest request) {
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.embedding(request).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    static Stream<Arguments> testCustomizableApi() {
+        return Stream.of(
+                Arguments.of(
+                        EmbeddingRequest.builder()
+                                .input(singletonList(INPUT))
+                                .build()
+                ),
+                Arguments.of(
+                        EmbeddingRequest.builder()
+                                .input(INPUT)
+                                .build()
+                )
+        );
+    }
+}

--- a/src/test/java/dev/ai4j/openai4j/image/RequestDisabledImagesGenerationTest.java
+++ b/src/test/java/dev/ai4j/openai4j/image/RequestDisabledImagesGenerationTest.java
@@ -1,0 +1,78 @@
+package dev.ai4j.openai4j.image;
+
+import static dev.ai4j.openai4j.image.ImageModel.*;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.api.Test;
+
+import dev.ai4j.openai4j.OpenAiClient;
+import dev.ai4j.openai4j.OpenAiHttpException;
+
+public class RequestDisabledImagesGenerationTest {
+
+    @Test
+    void generationShouldWork() {
+        OpenAiClient client = OpenAiClient
+            .builder()
+            .disableRequests()
+            .logRequests()
+            .logResponses()
+            .build();
+
+        GenerateImagesRequest request = GenerateImagesRequest
+            .builder()
+            .model(DALL_E_2) // so that you pay not much :)
+            .size(DALL_E_SIZE_256_x_256)
+            .prompt("Beautiful house on country side")
+            .build();
+
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.imagesGeneration(request).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @Test
+    void generationWithDownloadShouldWork() {
+        OpenAiClient client = OpenAiClient
+            .builder()
+            .disableRequests()
+            .logRequests()
+            .logResponses()
+            .withPersisting()
+            .build();
+
+        GenerateImagesRequest request = GenerateImagesRequest
+            .builder()
+            .model("dall-e-2") // so that you pay not much :)
+            .size(DALL_E_SIZE_256_x_256)
+            .prompt("Bird flying in the sky")
+            .build();
+
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.imagesGeneration(request).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @Test
+    void shouldPersistImageFromBase64Json() {
+        OpenAiClient client = OpenAiClient
+            .builder()
+            .disableRequests()
+            .withPersisting()
+            .logRequests()
+            .logResponses()
+            .build();
+
+        GenerateImagesRequest request = GenerateImagesRequest
+            .builder()
+            .model(DALL_E_2) // so that you pay not much :)
+            .size(DALL_E_SIZE_256_x_256)
+            .responseFormat(DALL_E_RESPONSE_FORMAT_B64_JSON)
+            .prompt("Beautiful house on country side")
+            .build();
+
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.imagesGeneration(request).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+}

--- a/src/test/java/dev/ai4j/openai4j/moderation/RequestDisabledModerationAsyncTest.java
+++ b/src/test/java/dev/ai4j/openai4j/moderation/RequestDisabledModerationAsyncTest.java
@@ -1,0 +1,74 @@
+package dev.ai4j.openai4j.moderation;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.Test;
+
+import dev.ai4j.openai4j.OpenAiClient;
+import dev.ai4j.openai4j.OpenAiHttpException;
+
+public class RequestDisabledModerationAsyncTest {
+
+    private static final String INPUT = "hello";
+
+    private final OpenAiClient client = OpenAiClient.builder()
+            .disableRequests()
+            .logRequests()
+            .logResponses()
+            .build();
+
+    @Test
+    void testSimpleApi() {
+
+        CompletableFuture<ModerationResult> future = new CompletableFuture<>();
+
+
+        client.moderation(INPUT)
+                .onResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .execute();
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @Test
+    void testCustomizableApi() {
+
+        ModerationRequest request = ModerationRequest.builder()
+                .input(INPUT)
+                .build();
+
+        CompletableFuture<ModerationResponse> future = new CompletableFuture<>();
+
+
+        client.moderation(request)
+                .onResponse(future::complete)
+                .onError(future::completeExceptionally)
+                .execute();
+
+
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .until(future::isCompletedExceptionally);
+
+        assertThatExceptionOfType(ExecutionException.class)
+            .isThrownBy(() -> future.get(30, SECONDS))
+            .havingCause()
+            .isInstanceOf(OpenAiHttpException.class)
+            .withMessage("Requests to the live system are disabled");
+    }
+}

--- a/src/test/java/dev/ai4j/openai4j/moderation/RequestDisabledModerationTest.java
+++ b/src/test/java/dev/ai4j/openai4j/moderation/RequestDisabledModerationTest.java
@@ -1,0 +1,38 @@
+package dev.ai4j.openai4j.moderation;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import dev.ai4j.openai4j.OpenAiClient;
+import dev.ai4j.openai4j.OpenAiHttpException;
+
+public class RequestDisabledModerationTest {
+
+    private static final String INPUT = "hello";
+
+    private final OpenAiClient client = OpenAiClient.builder()
+            .disableRequests()
+            .logRequests()
+            .logResponses()
+            .build();
+
+    @Test
+    void testSimpleApi() {
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.moderation(INPUT).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+
+    @Test
+    void testCustomizableApi() {
+
+        ModerationRequest request = ModerationRequest.builder()
+                .input(INPUT)
+                .build();
+
+        assertThatExceptionOfType(OpenAiHttpException.class)
+            .isThrownBy(() -> client.moderation(request).execute())
+            .withMessage("Requests to the live system are disabled");
+    }
+}


### PR DESCRIPTION
Since integrating with OpenAI costs real money, this introduces a way that I can "turn off" the integration. Maybe in an environment instead of making a "real" call I serve a default response.

This capability will certainly be extended further downstream (see https://github.com/quarkiverse/quarkus-langchain4j/issues/130), but the capability needs to be in the builder methods here, so this at least needs to be here so that it can be extended.

The design I took here is to try to keep the client from having to know anything about what to do in the case it is turned off. The case is treated simply like any client exception, which bubbles up as an `OpenAiHttpException` with a message indicating that the request was disabled.

I also added a bunch of test cases/classes which mirror the existing tests but enforce the fact that client is disabled. I may have gone overboard with the tests, but I thought better to be safe.

I'm happy to discuss and make any changes or alter naming conventions.