### PR TITLE
Add a method to customize the User Agent

### DIFF
--- a/src/main/java/dev/ai4j/openai4j/DefaultOpenAiClient.java
+++ b/src/main/java/dev/ai4j/openai4j/DefaultOpenAiClient.java
@@ -33,6 +33,7 @@ public class DefaultOpenAiClient extends OpenAiClient {
     private final OkHttpClient okHttpClient;
     private final OpenAiApi openAiApi;
     private final boolean logStreamingResponses;
+    private final String userAgent;
 
     public DefaultOpenAiClient(String apiKey) {
         this(new Builder().openAiApiKey(apiKey));
@@ -41,6 +42,7 @@ public class DefaultOpenAiClient extends OpenAiClient {
     private DefaultOpenAiClient(Builder serviceBuilder) {
         this.baseUrl = serviceBuilder.baseUrl;
         this.apiVersion = serviceBuilder.apiVersion;
+        this.userAgent = serviceBuilder.userAgent;
 
         OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder()
             .callTimeout(serviceBuilder.callTimeout)
@@ -66,6 +68,10 @@ public class DefaultOpenAiClient extends OpenAiClient {
 
         if (serviceBuilder.proxy != null) {
             okHttpClientBuilder.proxy(serviceBuilder.proxy);
+        }
+
+        if (serviceBuilder.userAgent != null) {
+            okHttpClientBuilder.addInterceptor(new GenericHeaderInjector(Collections.singletonMap("User-Agent", serviceBuilder.userAgent)));
         }
 
         if (serviceBuilder.logRequests) {

--- a/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
+++ b/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
@@ -67,6 +67,7 @@ public abstract class OpenAiClient {
         public Duration readTimeout = Duration.ofSeconds(60);
         public Duration writeTimeout = Duration.ofSeconds(60);
         public Proxy proxy;
+        public String userAgent;
         public boolean logRequests;
         public boolean logResponses;
         public LogLevel logLevel = DEBUG;
@@ -175,6 +176,11 @@ public abstract class OpenAiClient {
 
         public B proxy(Proxy proxy) {
             this.proxy = proxy;
+            return (B) this;
+        }
+
+        public B userAgent(String userAgent) {
+            this.userAgent = userAgent;
             return (B) this;
         }
 


### PR DESCRIPTION
Allow the customization of the "User-Agent" sent as a header by okhttp3.

My goal is to use it in LangChain4J OpenAI at https://github.com/langchain4j/langchain4j/tree/main/langchain4j-open-ai to have something similar to what we have in LangChain4J Azure OpenAI (see https://github.com/langchain4j/langchain4j/blob/200522f558509a67e940ae4c82284b85caaebef8/langchain4j-azure-open-ai/src/main/java/dev/langchain4j/model/azure/InternalAzureOpenAiHelper.java#L77 ).

This is important as this allows Azure OpenAI (and probably also OpenAI) to see which tool or library people are using, which is important to get support from them.