### PR TITLE
Allow additional headers in the OpenAiClient

### DIFF
--- a/src/main/java/dev/ai4j/openai4j/DefaultOpenAiClient.java
+++ b/src/main/java/dev/ai4j/openai4j/DefaultOpenAiClient.java
@@ -87,7 +87,7 @@ public class DefaultOpenAiClient extends OpenAiClient {
         }
         this.logStreamingResponses = serviceBuilder.logStreamingResponses;
 
-        if (serviceBuilder.additionalHeaders != null) {
+        if (serviceBuilder.customHeaders != null) {
             headers.putAll(serviceBuilder.customHeaders);
             okHttpClientBuilder.addInterceptor(new GenericHeaderInjector(headers));
         }

--- a/src/main/java/dev/ai4j/openai4j/DefaultOpenAiClient.java
+++ b/src/main/java/dev/ai4j/openai4j/DefaultOpenAiClient.java
@@ -88,7 +88,7 @@ public class DefaultOpenAiClient extends OpenAiClient {
         this.logStreamingResponses = serviceBuilder.logStreamingResponses;
 
         if (serviceBuilder.additionalHeaders != null) {
-            headers.putAll(serviceBuilder.additionalHeaders);
+            headers.putAll(serviceBuilder.customHeaders);
             okHttpClientBuilder.addInterceptor(new GenericHeaderInjector(headers));
         }
 

--- a/src/main/java/dev/ai4j/openai4j/DefaultOpenAiClient.java
+++ b/src/main/java/dev/ai4j/openai4j/DefaultOpenAiClient.java
@@ -2,6 +2,8 @@ package dev.ai4j.openai4j;
 
 import static dev.ai4j.openai4j.Json.GSON;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +46,8 @@ public class DefaultOpenAiClient extends OpenAiClient {
         this.apiVersion = serviceBuilder.apiVersion;
         this.userAgent = serviceBuilder.userAgent;
 
+        Map<String, String> headers = new HashMap<>();
+
         OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder()
             .callTimeout(serviceBuilder.callTimeout)
             .connectTimeout(serviceBuilder.connectTimeout)
@@ -63,7 +67,7 @@ public class DefaultOpenAiClient extends OpenAiClient {
         }
 
         if (serviceBuilder.organizationId != null) {
-            okHttpClientBuilder.addInterceptor(new GenericHeaderInjector(Collections.singletonMap("OpenAI-Organization", serviceBuilder.organizationId)));
+            headers.put("OpenAI-Organization", serviceBuilder.organizationId);
         }
 
         if (serviceBuilder.proxy != null) {
@@ -71,7 +75,7 @@ public class DefaultOpenAiClient extends OpenAiClient {
         }
 
         if (serviceBuilder.userAgent != null) {
-            okHttpClientBuilder.addInterceptor(new GenericHeaderInjector(Collections.singletonMap("User-Agent", serviceBuilder.userAgent)));
+            headers.put("User-Agent", serviceBuilder.userAgent);
         }
 
         if (serviceBuilder.logRequests) {
@@ -82,6 +86,11 @@ public class DefaultOpenAiClient extends OpenAiClient {
             okHttpClientBuilder.addInterceptor(new ResponseLoggingInterceptor(serviceBuilder.logLevel));
         }
         this.logStreamingResponses = serviceBuilder.logStreamingResponses;
+
+        if (serviceBuilder.additionalHeaders != null) {
+            headers.putAll(serviceBuilder.additionalHeaders);
+            okHttpClientBuilder.addInterceptor(new GenericHeaderInjector(headers));
+        }
 
         this.okHttpClient = okHttpClientBuilder.build();
 

--- a/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
+++ b/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
@@ -74,7 +74,7 @@ public abstract class OpenAiClient {
         public LogLevel logLevel = DEBUG;
         public boolean logStreamingResponses;
         public Path persistTo;
-        public Map<String, String> additionalHeaders;
+        public Map<String, String> customHeaders;
 
         public abstract T build();
 

--- a/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
+++ b/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
@@ -254,7 +254,7 @@ public abstract class OpenAiClient {
         }
 
         /**
-         * Additional headers to be added to the HTTP request.
+         * Custom headers to be added to each HTTP request.
          *
          * @param additionalHeaders map of headers
          * @return builder

--- a/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
+++ b/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
@@ -256,7 +256,7 @@ public abstract class OpenAiClient {
         /**
          * Custom headers to be added to each HTTP request.
          *
-         * @param additionalHeaders map of headers
+         * @param customHeaders a map of headers
          * @return builder
          */
         public B customHeaders(Map<String, String> customHeaders) {

--- a/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
+++ b/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
@@ -260,7 +260,7 @@ public abstract class OpenAiClient {
          * @return builder
          */
         public B customHeaders(Map<String, String> customHeaders) {
-            this.additionalHeaders = additionalHeaders;
+            this.customHeaders = customHeaders;
             return (B) this;
         }
     }

--- a/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
+++ b/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
@@ -20,6 +20,7 @@ import dev.ai4j.openai4j.moderation.ModerationResponse;
 import dev.ai4j.openai4j.moderation.ModerationResult;
 import dev.ai4j.openai4j.spi.OpenAiClientBuilderFactory;
 import dev.ai4j.openai4j.spi.ServiceHelper;
+import java.util.Map;
 
 import static dev.ai4j.openai4j.LogLevel.DEBUG;
 
@@ -73,6 +74,7 @@ public abstract class OpenAiClient {
         public LogLevel logLevel = DEBUG;
         public boolean logStreamingResponses;
         public Path persistTo;
+        public Map<String, String> additionalHeaders;
 
         public abstract T build();
 
@@ -248,6 +250,17 @@ public abstract class OpenAiClient {
          */
         public B persistTo(Path persistTo) {
             this.persistTo = persistTo;
+            return (B) this;
+        }
+
+        /**
+         * Additional headers to be added to the HTTP request.
+         *
+         * @param additionalHeaders map of headers
+         * @return builder
+         */
+        public B additionalHeaders(Map<String, String> additionalHeaders) {
+            this.additionalHeaders = additionalHeaders;
             return (B) this;
         }
     }

--- a/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
+++ b/src/main/java/dev/ai4j/openai4j/OpenAiClient.java
@@ -259,7 +259,7 @@ public abstract class OpenAiClient {
          * @param additionalHeaders map of headers
          * @return builder
          */
-        public B additionalHeaders(Map<String, String> additionalHeaders) {
+        public B customHeaders(Map<String, String> customHeaders) {
             this.additionalHeaders = additionalHeaders;
             return (B) this;
         }


### PR DESCRIPTION
# Description
We want to extend the OpenAiClient so that additional headers could be inserted into the client for reasons like network routing/usage control/audits etc.

# Approach
I've simply added the `additionalHeaders` field into the OpenAiClient so that it can be used by an interceptor for injecting headers whenever a call is made to OpenAI or a proxy.