### PR TITLE
Minor fix on handling headers in OpenAIClient

### DIFF
--- a/src/main/java/dev/ai4j/openai4j/DefaultOpenAiClient.java
+++ b/src/main/java/dev/ai4j/openai4j/DefaultOpenAiClient.java
@@ -70,6 +70,8 @@ public class DefaultOpenAiClient extends OpenAiClient {
         }
         if (serviceBuilder.customHeaders != null) {
             headers.putAll(serviceBuilder.customHeaders);
+        }
+        if (!headers.isEmpty()) {
             okHttpClientBuilder.addInterceptor(new GenericHeaderInjector(headers));
         }
 


### PR DESCRIPTION
# Description
This is a follow up bug fix to an earlier PR #19 that sets the generic header interceptor only when `CustomHeaders` are present. We should inject other headers from `User-Agent` or `Organization-Id` regardless of the presence of `CustomHeaders` 

cc: @langchain4j 