### PR TITLE
Add PDF content type

### DIFF
--- a/src/main/java/dev/ai4j/openai4j/chat/ContentType.java
+++ b/src/main/java/dev/ai4j/openai4j/chat/ContentType.java
@@ -2,5 +2,5 @@ package dev.ai4j.openai4j.chat;
 
 public enum ContentType {
 
-    TEXT, IMAGE_URL
+    TEXT, IMAGE_URL, PDF
 }


### PR DESCRIPTION
Now that OpenAI allows to upload PDFs in the prompt, I wanted to implement this feature in LangChain4j (in `InternalOpenAiHelper`), but the PDF content type is missing. So I am adding it.

Don't know if this should be `PDF` or `PDF_URL` like the image. Let me know